### PR TITLE
Fix EL6 RPM build

### DIFF
--- a/depends/libhdfs3/rpms/Dockerfile.centos6
+++ b/depends/libhdfs3/rpms/Dockerfile.centos6
@@ -3,18 +3,19 @@ FROM centos:6.9
 RUN yum -y install \
         centos-release-scl-rh \
         epel-release \
-        devtoolset-3-toolchain \
         wget \
         git \
         make \
-        g++ \
         bzip2-devel \
         zlib-devel \
         # For Protobuf 2.4+
         https://forensics.cert.org/cert-forensics-tools-release-el6.rpm \
     && \
     yum -y groupinstall 'Development Tools' && \
-    yum -y install protobuf-devel && \
+    yum -y install \
+        protobuf-devel \
+        devtoolset-3-toolchain \
+    && \
     wget http://sourceforge.net/projects/boost/files/boost/1.53.0/boost_1_53_0.tar.gz && \
     tar -xzf boost_1_53_0.tar.gz && \
     cd boost_1_53_0 && \

--- a/depends/libhdfs3/rpms/Dockerfile.centos6
+++ b/depends/libhdfs3/rpms/Dockerfile.centos6
@@ -1,12 +1,25 @@
-FROM centos:6.6
+FROM centos:6.9
 
-RUN yum -y install wget centos-release-scl-rh epel-release
+RUN yum -y install \
+        centos-release-scl-rh \
+        epel-release \
+        devtoolset-3-toolchain \
+        wget \
+        git \
+        make \
+        g++ \
+        bzip2-devel \
+        zlib-devel \
+        # For Protobuf 2.4+
+        https://forensics.cert.org/cert-forensics-tools-release-el6.rpm \
+    && \
+    yum -y groupinstall 'Development Tools' && \
+    yum -y install protobuf-devel && \
+    wget http://sourceforge.net/projects/boost/files/boost/1.53.0/boost_1_53_0.tar.gz && \
+    tar -xzf boost_1_53_0.tar.gz && \
+    cd boost_1_53_0 && \
+    ./bootstrap.sh --prefix=/usr --with-libraries=program_options,chrono,atomic,thread,system,iostreams && \
+    ./b2 install link=shared runtime-link=shared threading=multi,single --layout=tagged
 
-# For Protobuf 2.4+
-RUN yum -y localinstall https://forensics.cert.org/cert-forensics-tools-release-el6.rpm
-
-RUN wget http://repo.enetres.net/enetres.repo -O /etc/yum.repos.d/enetres.repo
-RUN yum -y install devtoolset-3-toolchain
-RUN yum -y install protobuf-devel boost-devel
 COPY entrypoint.sh /usr/local/bin
 CMD "/usr/local/bin/entrypoint.sh"

--- a/depends/libhdfs3/rpms/build.sh
+++ b/depends/libhdfs3/rpms/build.sh
@@ -35,7 +35,7 @@ build_google_test() {
 install_depends() {
     yum install -y epel-release || die "cannot install epel"
     yum install -y \
-        which make rpmdevtools gcc-c++ cmake boost-devel libxml2-devel libuuid-devel krb5-devel libgsasl-devel \
+        which make rpmdevtools gcc-c++ cmake libxml2-devel libuuid-devel krb5-devel libgsasl-devel \
         protobuf-devel || die "cannot install dependencies"
 }
 

--- a/depends/libhdfs3/rpms/libhdfs3.spec
+++ b/depends/libhdfs3/rpms/libhdfs3.spec
@@ -36,11 +36,6 @@ BuildRequires: libxml2-devel
 BuildRequires: krb5-devel
 BuildRequires: libgsasl-devel
 BuildRequires: protobuf-devel
-Requires: libuuid
-Requires: libxml2
-Requires: krb5-workstation
-Requires: libgsasl
-Requires: protobuf >= 2.4.0
 
 Requires: protobuf >= 2.4.0
 Requires: libxml2

--- a/depends/libhdfs3/rpms/libhdfs3.spec
+++ b/depends/libhdfs3/rpms/libhdfs3.spec
@@ -36,6 +36,11 @@ BuildRequires: libxml2-devel
 BuildRequires: krb5-devel
 BuildRequires: libgsasl-devel
 BuildRequires: protobuf-devel
+Requires: libuuid
+Requires: libxml2
+Requires: krb5-workstation
+Requires: libgsasl
+Requires: protobuf >= 2.4.0
 
 Requires: protobuf >= 2.4.0
 Requires: libxml2


### PR DESCRIPTION
The EL6 RPM build was failing because we were installing boost 1.53
from a weird place, and it stopped serving the RPMs. I updated the
build to build boost 1.53 from source.